### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and publish Docker image
         if: ${{ steps.get-next-version.outputs.skipped == 'false' }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: "bsord/bsord-homepage"
           username: ${{ secrets.CR_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore